### PR TITLE
Fix missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,7 @@ pydeck==0.8.1b0
 requests==2.31.0
 holidays==0.34.0
 filelock==3.12.4
+
+# Web Framework
+uvicorn==0.24.0
+fastapi==0.110.0


### PR DESCRIPTION
## Summary
- ensure uvicorn and fastapi are installed

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pages')*

------
https://chatgpt.com/codex/tasks/task_e_68402b7d3484832fbffccc7b094c2bb7